### PR TITLE
Feat: migrate account storage from JSON to TXT format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ With these insights, they can reroute traffic dynamically to avoid bottlenecks, 
 
 ## File Structure
 
-- **account.json** it save your account info like email and password
+- ~~**account.json** it save your account info like email and password~~
+- **account.txt** it save your account info like email and password `email:password`
 - **proxy.txt** to store proxy you want to use, each line for 1 proxy `http://username:pass@ip:port`
 - **token.json** it save access token after you login
 

--- a/account.txt
+++ b/account.txt
@@ -1,0 +1,1 @@
+test@gmail.com:password

--- a/services/login.js
+++ b/services/login.js
@@ -4,13 +4,19 @@ const { HttpsProxyAgent } = require("https-proxy-agent");
 const { logger } = require("../utils/logger");
 const fs = require('fs');
 
-const ACCOUNT_FILE = 'account.json';
+const ACCOUNT_FILE = 'account.txt';
 
 // Function to read all accounts from account.json
 async function readUsersFromFile() {
     try {
         const fileData = await fs.promises.readFile(ACCOUNT_FILE, 'utf8');
-        return JSON.parse(fileData);
+        return fileData
+            .split('\n')
+            .filter(line => line.trim() !== '')
+            .map(line => {
+                const [email, password] = line.split(':').map(s => s.trim());
+                return { email, password };
+            });
     } catch (error) {
         logger('Error reading users from file', 'error', error);
         return [];


### PR DESCRIPTION
This PR changes the account storage format from JSON to plain text for easier manual editing and maintenance. The main changes include:

- Replace account.json with account.txt
- Update file parsing logic to handle the new format
- Each account entry should be in "email:password" format, one per line

Changes:
1. Modified readUsersFromFile() to parse plain text instead of JSON
2. Added documentation for the new file format

Impact:
- Existing users need to migrate their account.json to the new format
- No changes to application logic or user experience